### PR TITLE
Fixed possible typo in docker documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Note: docker has not been fully tested, but has been reported to work.
 ### Docker example
 
 ```shell
-envkernel singularity --name=NAME  --pwd --bind /m/jh/coursedata/:/coursedata /path/to/image.simg
+envkernel docker --name=NAME  --pwd --bind /m/jh/coursedata/:/coursedata /path/to/image.simg
 ```
 
 ### Docker mode arguments
@@ -172,7 +172,7 @@ envkernel singularity --name=NAME  --pwd --bind /m/jh/coursedata/:/coursedata /p
 General invocation:
 
 ```shell
-envkernel singularity --name=NAME [envkernel options] [singularity options] [image]
+envkernel docker --name=NAME [envkernel options] [singularity options] [image]
 ```
 
 * `image`: Required positional argument: name of docker image to run.


### PR DESCRIPTION
This might be more of a question than a PR, but does `envkernel` require Singularity to be installed in order to run Jupyter kernels from Docker images?

I know that Singularity can run Docker images, so hypothetically it would make sense if `envkernel` ran Jupyter kernels from Docker images using Singularity. (I.e. `singularity run` instead of `docker run`.)

This seems to be reflected in the documentation for Docker as currently written, where the command for running Jupyter kernels via Docker images seems to be `envkernel singularity` instead of a dedicated `envkernel docker`.

However, [looking at the code](https://github.com/NordicHPC/envkernel/blob/master/envkernel.py#L367) it seems like `envkernel` _does_ have a separate `envkernel docker` subcommand that runs Jupyter kernels using `docker run` (and not `singularity run`), so it seems like the current documentation might be a typo. 

Of course, since I just heard about this tool this morning and understand very little about it, I am not all sure one way or the other. Any clarification on this matter would be greatly appreciated.