### PR TITLE
Add login shell mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,34 @@ envkernel lmod --name=NAME [envkernel options] [module ...]
 
 
 
+## Login shell
+
+This runs the kernel through a login shell, for example `bash -l
+-c [kernel-cmd]`.
+
+### Login shell example
+
+```shell
+envkernel loginshell --name=python3-clean
+```
+
+### Login shell arguments
+
+```shell
+envkernel loginshell --name=NAME [envkernel options] [login shell options]
+```
+
+* `--shell=SHELL`.  Shell to invoke, default=`bash`.  The shell has to
+  accept the `-l` (to amke it a login shell) and `-c` options (to
+  accept the kernel command to run).
+
+Any other unknown argument will be passed through to the shell, so you
+could, for example, use `--norc` for bash.
+
+
+
+
+
 ## Other kernels
 
 Envkernel isn't specific to the IPython kernel.  It defaults to

--- a/envkernel.py
+++ b/envkernel.py
@@ -597,6 +597,30 @@ class singularity(envkernel):
 
 
 
+class loginshell(envkernel):
+    def setup(self):
+        super().setup()
+        parser = argparse.ArgumentParser()
+        parser.add_argument('--shell', default="bash")
+        args, unknown_args = parser.parse_known_args(self.argv)
+
+        kernel = self.get_kernel()
+        original_argv = printargs(kernel['argv'])
+        kernel['argv'] = [
+            args.shell,
+            "-l",
+            *unknown_args,
+            "-c",
+            printargs(kernel['argv']),
+        ]
+        if 'display_name' not in kernel:
+            kernel['display_name'] = "{} with login shell".format(
+            original_argv)
+        self.install_kernel(kernel, name=self.name, user=self.user,
+                            replace=self.replace, prefix=self.prefix)
+
+
+
 def main(argv=sys.argv):
     mod = argv[1]
     if mod in {'-h', '--help'}:


### PR DESCRIPTION
- This will run with (for example with bash) `bash -l -c kernel-cmd`,
  so that we get a clean user shell.  It could be combined with
  `--norc` to avoid user RC files.

- This requires adjusting tests some, since this mode works
  fundamentally differently: it sets the kernel to directly invoke
  `bash -l`, instead of invoking envkernel to do something.

  - Some extra login for splitting the envkernel 'ek' options from the
    kernel 'k' options.

  - Excluding loginshell from running on some of the tests, which
    fundamentally work differently.