### PR TITLE
Singularity/docker: change argument order in run stage

### DIFF
--- a/envkernel.py
+++ b/envkernel.py
@@ -388,8 +388,8 @@ class docker(envkernel):
             'docker',
             'run',
             '--connection-file', '{connection_file}',
-            *unknown_args,
             args.image,
+            *unknown_args,
             '--',
             *kernel['argv'],
         ]
@@ -523,8 +523,8 @@ class singularity(envkernel):
             'singularity', 'run',
             '--connection-file', '{connection_file}',
             #*[ '--mount={}'.format(x) for x in args.mount],
-            *unknown_args,
             args.image,
+            *unknown_args,
             '--',
             *kernel['argv'],
         ]

--- a/test_envkernel.py
+++ b/test_envkernel.py
@@ -262,14 +262,14 @@ def test_docker(d):
     kern = install(d, "docker --some-arg=AAA IMAGE1")
     #assert kern['argv'][0] == 'envkernel'  # defined above
     assert kern['ek'][1:3] == ['docker', 'run']
-    assert kern['ek'][-1] == 'IMAGE1'
+    assert kern['ek'][-2] == 'IMAGE1'
     assert '--some-arg=AAA' in kern['ek']
 
 def test_singularity(d):
     kern = install(d, "singularity --some-arg=AAA /PATH/TO/IMAGE2")
     #assert kern['argv'][0] == 'envkernel'  # defined above
     assert kern['ek'][1:3] == ['singularity', 'run']
-    assert kern['ek'][-1] == '/PATH/TO/IMAGE2'
+    assert kern['ek'][-2] == '/PATH/TO/IMAGE2'
     assert '--some-arg=AAA' in kern['ek']
 
 


### PR DESCRIPTION
- Related: #4
- Closes: #4
- Put the image image argument first in the kernel argv, so that there
  is less chance of mixing up the options and arguments.  During the
  docker/singularity exec phase, the image should still be at the very
  end (where I *think* it is normally expected).
- This is not yet tested for real functionality, but the tests pass.
  I will delay merging until I do more testing.