### PR TITLE
Reorder unknown arguments

### DIFF
--- a/envkernel.py
+++ b/envkernel.py
@@ -538,8 +538,8 @@ class singularity(envkernel):
             'singularity', 'run',
             '--connection-file', '{connection_file}',
             #*[ '--mount={}'.format(x) for x in args.mount],
-            *unknown_args,
             args.image,
+            *unknown_args,
             '--',
             *kernel['argv'],
         ]


### PR DESCRIPTION
Old changes. Without this adding an extra argument (like --bind) would make singularity fail to find the image